### PR TITLE
fix: changes specific header in response to asynchronous requests for correct responses (#97)

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -14,7 +14,7 @@ const Constants = {
   BG_DB_PROBLEMS: 'boj-extended-DB-PROBLEMS',
   BG_PROBLEM_FETCH_URL:
     'https://raw.githubusercontent.com/joonas-yoon/boj-extended/release/db.json',
-  BG_ORIGIN_HOSTNAME: 'www.acmicpc.net',
+  BG_ORIGIN_HOSTNAME: 'acmicpc.net',
   THEMES: {
     // auto: '시스템 설정',
     light: '밝은 테마',

--- a/js/constants.js
+++ b/js/constants.js
@@ -14,6 +14,7 @@ const Constants = {
   BG_DB_PROBLEMS: 'boj-extended-DB-PROBLEMS',
   BG_PROBLEM_FETCH_URL:
     'https://raw.githubusercontent.com/joonas-yoon/boj-extended/release/db.json',
+  BG_ORIGIN_HOSTNAME: 'www.acmicpc.net',
   THEMES: {
     // auto: '시스템 설정',
     light: '밝은 테마',

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,6 +1,6 @@
 const Utils = {
   requestAjax: function (url, callback) {
-    onceInitBeforeSendHeaders();
+    // onceInitBeforeSendHeaders();
     const httpRequest = new XMLHttpRequest();
 
     if (!httpRequest) {
@@ -265,24 +265,24 @@ function addElementToBar(element) {
   bar.appendChild(divider);
   bar.appendChild(element);
 }
-/**
- * @author David Walsh
- * @origin https://davidwalsh.name/javascript-once
- * 
- * @param {*} fn  The function to call only once
- * @param {*} context The context to run the function in
- * @returns  The function that was passed in
- */
-function once(fn, context) { 
-  let result = null;
-  return function() { 
-      if (fn) {
-          result = fn.apply(context || this, arguments);
-          fn = null;
-      }
-      return result;
-  };
-}
+// /**
+//  * @author David Walsh
+//  * @origin https://davidwalsh.name/javascript-once
+//  * 
+//  * @param {*} fn  The function to call only once
+//  * @param {*} context The context to run the function in
+//  * @returns  The function that was passed in
+//  */
+// function once(fn, context) { 
+//   let result = null;
+//   return function() { 
+//       if (fn) {
+//           result = fn.apply(context || this, arguments);
+//           fn = null;
+//       }
+//       return result;
+//   };
+// }
 
 /**
  * run it once, you won't get an empty response even if you call fetch function.
@@ -303,7 +303,8 @@ function initBeforeSendHeaders(){
   );
 }
 
-var onceInitBeforeSendHeaders = once(initBeforeSendHeaders);
+// var onceInitBeforeSendHeaders = once(initBeforeSendHeaders);
+initBeforeSendHeaders();
 
 /**
  * @deprecated since version 1.7.6
@@ -347,7 +348,7 @@ async function fetchProblemsByUser(id) {
     cacheData &&
     Number(cacheData.lastUpdated || 0) + duration < currentTimestamp;
   if (cacheData == null || cacheData.problems == null || isDateExpired) {
-    onceInitBeforeSendHeaders();
+    // onceInitBeforeSendHeaders();
     // run request and parse
     const response = await fetch(`/user/${id}`);
     console.group(`request new problems solved by ${id}`);

--- a/js/utils.js
+++ b/js/utils.js
@@ -298,7 +298,7 @@ function initBeforeSendHeaders(){
       }
       return { requestHeaders: details.requestHeaders };
     },
-    {urls: [`https://*${BG_ORIGIN_HOSTNAME}/*`]},
+    {urls: [`https://*.${BG_ORIGIN_HOSTNAME}/*`]},
     [ 'blocking', 'requestHeaders', 'extraHeaders']
   );
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -274,7 +274,7 @@ function addElementToBar(element) {
  * @returns  The function that was passed in
  */
 function once(fn, context) { 
-  var result;
+  let result = null;
   return function() { 
       if (fn) {
           result = fn.apply(context || this, arguments);
@@ -290,7 +290,7 @@ function once(fn, context) {
 function initBeforeSendHeaders(){
   chrome.webRequest.onBeforeSendHeaders.addListener(
     function(details) {
-      for (var i = 0; i < details.requestHeaders.length; ++i) {
+      for (let i = 0; i < details.requestHeaders.length; ++i) {
         if (details.requestHeaders[i].name === 'sec-fetch-dest') {
           details.requestHeaders[i].value = 'document';
           break;
@@ -298,7 +298,7 @@ function initBeforeSendHeaders(){
       }
       return { requestHeaders: details.requestHeaders };
     },
-    {urls: ['https://acmicpc.net/*']},
+    {urls: [`https://*${BG_ORIGIN_HOSTNAME}/*`]},
     [ 'blocking', 'requestHeaders', 'extraHeaders']
   );
 }

--- a/manifest.json
+++ b/manifest.json
@@ -52,7 +52,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["storage", "webRequest", "webRequestBlocking"],
+  "permissions": ["storage", "webRequest", "declarativeNetRequest"],
   "host_permissions": [
     "https://www.acmicpc.net/?",
     "https://www.acmicpc.net/*"

--- a/manifest.json
+++ b/manifest.json
@@ -52,7 +52,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "webRequest", "webRequestBlocking"],
   "host_permissions": [
     "https://www.acmicpc.net/?",
     "https://www.acmicpc.net/*"


### PR DESCRIPTION
**연결된 이슈**
#97 

**내용**
- #80 에 해당하는 이슈 해결을 위한 fetch 요청 시에 헤더를 수정하도록 변경
  - utils.js 내의 once, initBeforeSendHeaders, onceInitBeforeSendHeaders 함수 추가
  - utils.js 내의 Utils.requestsAjax, fetchProblemsByUser 함수 일부 수정
  - constants.js 내의 BG_ORIGIN_HOSTNAME 상수 추가
  - manifest.json 내의 버전 올림 및 webRequest, webRequestBlocking 권한 추가

- 기능 테스트를 상세히 진행하지 못하였으므로 기능 검토 부탁드립니다.