### PR TITLE
fix: align the problem box more prettier

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -285,6 +285,8 @@ a[href^='/problem'].problem-link-style-box {
   border-radius: 5px !important;
   line-height: 1.25;
   min-height: 18px;
+  min-width: 4.25em;
+  text-align: center;
 }
 
 a[href^='/problem'].problem-link-style-box.result-ac {


### PR DESCRIPTION
**내용**
유저 정보에 있는 문제 링크 박스를 조금 더 미려하게 보이도록 수정하였습니다.

**스크린샷 (선택)**
![이전](https://user-images.githubusercontent.com/31976959/187119309-0fb2ffcc-8f76-407b-a861-f14597d587a2.png) 이전

![이후](https://user-images.githubusercontent.com/31976959/187119150-34d998dc-12af-4f2a-b367-3c639c90a40d.png) 이후
