### PR TITLE
feat: enhance unranked/not ratable blockquote text color visibility for dark and rigel themes

### DIFF
--- a/src/css/theme-dark.css
+++ b/src/css/theme-dark.css
@@ -565,6 +565,10 @@ html[theme='dark'] #contest_scoreboard a {
 html[theme='dark'] #contest_statistics a {
   color: #a0a0a0;
 }
+html[theme='dark'] .solvedac-tier-name-0::after,
+html[theme='dark'] .solvedac-tier-name--1::after {
+  color: #dfdfdf;
+}
 /* start: /user/.+ */
 html[theme='dark'] .tab-v2 .nav-tabs li.active a {
   background: #222;

--- a/src/css/theme-rigel.css
+++ b/src/css/theme-rigel.css
@@ -698,6 +698,10 @@ html[theme='rigel'] .tabs-container .nav-tabs > li.active > a:focus {
   border-bottom-color: transparent;
   background-color: #292929;
 }
+html[theme='rigel'] .solvedac-tier-name-0::after,
+html[theme='rigel'] .solvedac-tier-name--1::after {
+  color: #e6e6dc;
+}
 /* end: /contest/board */
 html[theme='rigel'] a.list-group-item.active > .badge,
 html[theme='rigel'] .nav-pills > .active > a > .badge {


### PR DESCRIPTION
<!-- 👋 안녕하세요. ✨PR✨에 감사드립니다. -->
<!-- 해당 PR이 어떤 내용을 담고 있는 지, 간략하게 작성해주셔도 좋습니다. -->

**연결된 이슈**
- #181


**내용**
본 PR에서는 solved.ac 티어 이름이 BOJ Extended의 dark/rigel 테마 이용 시 가시성이 떨어져 잘 보이지 않는 문제를 해결하기 위해, 해당 티어 색상을 흰색으로 보이도록 테마를 개선했습니다.

- 티어가 `Unrated`이거나 `Not Ratable`인 경우에 한하여 적용됩니다.
- 색상은 dark 테마의 경우 `#dfdfdf`, rigel 테마의 경우 `#e6e6dc`입니다. 이는 각각의 테마에서 사용하는 일반 텍스트 색상과 동일합니다.
- 두 테마 모두 색상을 `#ffffff`로 두는 대안도 고려해볼 수 있을 만합니다.

참고로, BOJ에서 티어 이름을 보이게 하기 위해서는 BOJ의 [보기 설정](https://acmicpc.net/setting/view) 페이지에서 아래의 옵션을 활성화하시면 됩니다.

<img src="https://github.com/user-attachments/assets/8b6c2376-a6a9-43f2-8790-ee01be066bad" width="400px">



**스크린샷 (선택)**

<img src="https://github.com/user-attachments/assets/fba63889-91c2-4c43-99ab-d2dc0227e40a" width="700px">