### PR TITLE
feat: add toggle button for invert filter on each image

### DIFF
--- a/src/css/theme-dark.css
+++ b/src/css/theme-dark.css
@@ -828,7 +828,7 @@ html[theme='dark'] body[image-filter='true'] #logo-header,
 html[theme='dark']
   body[image-filter='true']
   #problem-body
-  img:not(.level_badge) {
+  img:not(.level_badge):not(.prevent-img-filter) {
   filter: invert(100%) hue-rotate(180deg) brightness(120%) contrast(72.5%);
   -webkit-filter: invert(100%) hue-rotate(180deg) brightness(120%)
     contrast(72.5%);

--- a/src/css/theme-rigel.css
+++ b/src/css/theme-rigel.css
@@ -864,7 +864,7 @@ html[theme='rigel'] body[image-filter='true'] #logo-header,
 html[theme='rigel']
   body[image-filter='true']
   #problem-body
-  img:not(.level_badge) {
+  img:not(.level_badge):not(.prevent-img-filter) {
   filter: invert(100%) hue-rotate(180deg) brightness(120%) contrast(72.5%);
   -webkit-filter: invert(100%) hue-rotate(180deg) brightness(120%)
     contrast(72.5%);

--- a/src/js/features/global.js
+++ b/src/js/features/global.js
@@ -410,13 +410,7 @@ function extendGlobal() {
         toggleButton.style.background = 'gray';
         toggleButton.style.color = 'black';
         toggleButton.addEventListener('click', () => {
-          const isImageFilterActivated =
-            document.body.getAttribute('image-filter') === 'true';
-
-          document.body.setAttribute(
-            'image-filter',
-            (!isImageFilterActivated).toString()
-          );
+          imageElement.classList.toggle('prevent-img-filter');
         });
 
         // 이미지 노드의 부모 노드가 이미지 대신 컨테이너를 자식으로 가지도록 하고, 컨테이너 내부에는 이미지와 버튼을 삽입.


### PR DESCRIPTION
<!-- 👋 안녕하세요. ✨PR✨에 감사드립니다. -->
<!-- 해당 PR이 어떤 내용을 담고 있는 지, 간략하게 작성해주셔도 좋습니다. -->

**연결된 이슈**
<!-- 연결된 이슈가 있다면 #00 와 같이 적어주시면 됩니다. -->
#189

**내용**
<!-- 커밋들에 대한 간단한 내용을 여기에 적어주세요. -->
문제 본문의 각 이미지마다 아래 달린 버튼을 통해 반전 필터를 토글할 수 있도록 했습니다.

구현은 페이지 로드 후 이미지 아래 버튼을 동적으로 생성하고, 클릭시 이미지에 `prevent-img-filter` 클래스가 토글되도록 했습니다. 그리고 문제 본문 이미지에 `prevent-img-filter` 클래스가 존재할 경우만 반전 필터가 적용되도록 스타일을 수정했습니다.

최근 업데이트된 방식에 맞춰 `document.body`의 `image-filter` 토글하도록 방식을 바꿔 구현해봤었는데, 이슈 작성 당시 컨셉이 '각 이미지마다 필터 토글 버튼 추가'였던 탓에 버튼은 여러개 생기고 한 개 누르면 모든 이미지의 반전 필터가 토글되니 어색함이 느껴져서 다시 초기 방식으로 되돌렸습니다.

Pull Request를 일단 쓰긴 했는데 현시점에서 이미 이미지 반전 필터 방지 기능을 추가해주신 상황이니 이게 쓸모있을진 모르겠네요 ㅎㅎ;;

**스크린샷 (선택)**

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/8feb9433-3732-4778-94e0-b1a6ffc5bf3b" />
