### PR TITLE
fix: fixes `[object Object]` name display in option timer dashboard page

### DIFF
--- a/src/options/option-timer.js
+++ b/src/options/option-timer.js
@@ -14,7 +14,7 @@
   const getProblemName = (pid) => {
     try {
       const dbJson = JSON.parse(PROBLEM_DB[Constants.BG_DB_PROBLEMS]);
-      return dbJson['problems'][pid];
+      return dbJson['problems'][pid]['title'];
     } catch (error) {
       console.error(error);
       return '<문제 제목을 불러오는 데 실패했습니다>';


### PR DESCRIPTION
<!-- 👋 안녕하세요. ✨PR✨에 감사드립니다. -->
<!-- 해당 PR이 어떤 내용을 담고 있는 지, 간략하게 작성해주셔도 좋습니다. -->

**연결된 이슈**
- #192


**내용**
본 PR에서는 BOJ Extended의 설정 페이지의 [문제 타이머] 메뉴에서 모든 타이머의 이름이 `[object Object]`로 보이는 문제를 해결했습니다.

타이머의 이름을 표시하기 위해 사용되는 함수 `getProblemName`은 문제의 정보를 불러오는 데 성공하면 문제의 이름을 문자열 형태로 가져오는 것이 의도된 사항이라 추측합니다. 다만, 실제로 반환하는 값은 오브젝트였습니다. 아래는 예시입니다.

```json
{
  "title": "이건 무슨 진법이지?",
  "level": 4
}
```

위의 오브젝트를 그대로 렌더링하려고 하면 `[object Object]`가 될 것이므로, 이 중 `title` 키 값에 해당하는 값만 가져오도록 변경사항을 냈습니다. `getProblemName`의 경우 사용처가 타이머밖에 없는 것을 확인하여, 타이머 쪽의 로직은 그대로 두고 함수를 수정했습니다. 하지만 혹시 모르니 `getProblemName`의 다른 사용처가 있는지 검토해주시면 좋을 것 같습니다.

**스크린샷 (선택)**
- 개선 이전
<img width="457" height="272" alt="Image" src="https://github.com/user-attachments/assets/91ad0b57-6854-4ee8-9380-409391301952" />

- 개선 이후
<img width="261" height="83" alt="image" src="https://github.com/user-attachments/assets/80e18895-08fc-4b9e-9b87-36a8e57cde10" />
